### PR TITLE
Reduce particles + improve transition

### DIFF
--- a/assets/JS/app.js
+++ b/assets/JS/app.js
@@ -1,7 +1,7 @@
 particlesJS("particles-js", {
   particles: {
     number: {
-      value: 200,
+      value: 120,
       density: {
         enable: true,
         value_area: 500,

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -218,11 +218,11 @@ canvas {
     transition-delay: 350ms;
 }
 .logo:nth-child(7) {
-    transition-delay: 400ms;
+    transition-delay: 250ms;
 } 
 .logo:nth-child(8) {
-    transition-delay: 450ms;
+    transition-delay: 300ms;
 } 
 .logo:nth-child(9) {
-    transition-delay: 500ms;
+    transition-delay: 350ms;
 } 


### PR DESCRIPTION
Reduce particles from 200 to 110 to improve phone performance and reduced transition speed for logo 7,8,9th child.